### PR TITLE
Notifiers can return an error

### DIFF
--- a/reload.go
+++ b/reload.go
@@ -17,15 +17,13 @@ type ReloaderFunc func(ctx context.Context, id string) error
 // Reload satisifies Reloader interface.
 func (r ReloaderFunc) Reload(ctx context.Context, id string) error { return r(ctx, id) }
 
-// Notifier triggers the reload process.
+// Notifier knows how to trigger a reload process.
 type Notifier interface {
-	Notify(ctx context.Context) string
+	Notify(ctx context.Context) (string, error)
 }
 
 // NotifierFunc is a helper to create notifiers from functions.
-type NotifierFunc func(ctx context.Context) string
+type NotifierFunc func(ctx context.Context) (string, error)
 
 // Notify satisifies Notifier interface.
-func (n NotifierFunc) Notify(ctx context.Context) string {
-	return n(ctx)
-}
+func (n NotifierFunc) Notify(ctx context.Context) (string, error) { return n(ctx) }


### PR DESCRIPTION
Before this PR, the notifiers didn't have a way of signaling an error to the manager to tell that they could not trigger a reload.

Now they can and the manager will end its execution with an error.

This could happen when the channel used to notify is closed.

However the user always has the ability to mask the error and don't return it so, this approach is flexible enough to give the user the power to handle the error as it wants.