### PR TITLE
Add NotifierChan helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- NotifierChan helper.
 - Reload manager with priority batching.
 - Notifier interface and NotifierFunc helper.
 - Reloader interface and ReloaderFunc helper.

--- a/manager.go
+++ b/manager.go
@@ -106,9 +106,7 @@ func (m *Manager) Run(ctx context.Context) error {
 		}(n)
 	}
 
-	// Wait until the context ends or we receive a signal from
-	// the first notifier, then stop all the other notifiers we
-	// are waiting for.
+	// Wait until the context ends or we receive a signal from a notifier.
 	for {
 		select {
 		case notifierSignal := <-signal:

--- a/reload.go
+++ b/reload.go
@@ -27,3 +27,12 @@ type NotifierFunc func(ctx context.Context) (string, error)
 
 // Notify satisifies Notifier interface.
 func (n NotifierFunc) Notify(ctx context.Context) (string, error) { return n(ctx) }
+
+// NotifierChan is a helper to create notifiers from channels.
+//
+// Note: Closing the channel is not safe, as the channel will be reused and read
+// from it multiple times for each notification.
+type NotifierChan <-chan string
+
+// Notify satisifies Notifier interface.
+func (n NotifierChan) Notify(ctx context.Context) (string, error) { return <-n, nil }


### PR DESCRIPTION
Add helper to get notifiers from string channels.

There are times where a simple channel is enough for the Notifier, for example, an HTTP handler:

```go
reloadManager := reload.NewManager()

// Add reload notifier.
reloadChan := make(chan string)
reloadManager.On(reload.NotifierChan(reloadChan))

// On HTTP request to `/-/reload` trigger reload.
mux := http.NewServeMux()
mux.Handle("/-/reload", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
  reloadChan <- "http"
}))
```